### PR TITLE
fix(budget): Use budget type over budget id

### DIFF
--- a/src/main/java/com/factotum/rin/dto/BudgetSummary.java
+++ b/src/main/java/com/factotum/rin/dto/BudgetSummary.java
@@ -1,5 +1,6 @@
 package com.factotum.rin.dto;
 
+import com.factotum.rin.enumeration.BudgetType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -19,14 +20,14 @@ public class BudgetSummary {
 
     private Integer categoryId;
 
-    private Integer transactionTypeId;
+    private BudgetType budgetType;
 
     private BigDecimal planned;
 
-    public BudgetSummary(String category, Integer categoryId, Integer transactionTypeId, Double planned) {
+    public BudgetSummary(String category, Integer categoryId, BudgetType budgetType, Double planned) {
         this.category = category;
         this.categoryId = categoryId;
-        this.transactionTypeId = transactionTypeId;
+        this.budgetType = budgetType;
         this.planned = BigDecimal.valueOf(planned);
     }
 }

--- a/src/main/java/com/factotum/rin/dto/TransactionBudgetSummary.java
+++ b/src/main/java/com/factotum/rin/dto/TransactionBudgetSummary.java
@@ -1,5 +1,6 @@
 package com.factotum.rin.dto;
 
+import com.factotum.rin.enumeration.BudgetType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -20,8 +21,8 @@ import java.time.format.DateTimeFormatter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionBudgetSummary {
 
-    @JsonProperty("transactionType")
-    private String transactionType;
+    @JsonProperty("budgetType")
+    private BudgetType budgetType;
 
     @JsonProperty("category")
     private String category;
@@ -45,10 +46,15 @@ public class TransactionBudgetSummary {
     private boolean expected;
 
     public TransactionBudgetSummary(
-            String transactionType, String category, Integer month,
-            Integer year, Double planned, BigDecimal actual, boolean expected) {
+            BudgetType budgetType,
+            String category,
+            Integer month,
+            Integer year,
+            Double planned,
+            BigDecimal actual,
+            boolean expected) {
 
-        this.transactionType = transactionType;
+        this.budgetType = budgetType;
         this.category = category;
         this.month = month;
         this.monthText = LocalDateTime.now().withMonth(month).format(DateTimeFormatter.ofPattern("MMMM"));

--- a/src/main/java/com/factotum/rin/dto/TransactionTotal.java
+++ b/src/main/java/com/factotum/rin/dto/TransactionTotal.java
@@ -1,6 +1,7 @@
 package com.factotum.rin.dto;
 
 
+import com.factotum.rin.enumeration.BudgetType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -17,8 +18,8 @@ import java.math.BigDecimal;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionTotal {
 
-    @JsonProperty("transactionType")
-    private String transactionType;
+    @JsonProperty("budgetType")
+    private BudgetType budgetType;
 
     @JsonProperty("total")
     private BigDecimal total;

--- a/src/main/java/com/factotum/rin/enumeration/BudgetType.java
+++ b/src/main/java/com/factotum/rin/enumeration/BudgetType.java
@@ -1,0 +1,5 @@
+package com.factotum.rin.enumeration;
+
+public enum BudgetType {
+    INCOME, EXPENSE
+}

--- a/src/main/java/com/factotum/rin/http/TransactionService.java
+++ b/src/main/java/com/factotum/rin/http/TransactionService.java
@@ -1,6 +1,7 @@
 package com.factotum.rin.http;
 
 import com.factotum.rin.dto.TransactionTotal;
+import com.factotum.rin.enumeration.BudgetType;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +17,7 @@ public interface TransactionService {
     TransactionTotal getTransactionTotal(
             @RequestParam(name = "year") int year,
             @RequestParam(name = "month") int month,
-            @RequestParam(name = "transactionTypeId") int transactionTypeId,
+            @RequestParam(name = "budgetType") BudgetType budgetType,
             @RequestParam(name = "budgetIds") Set<Long> budgetIds);
 
 }

--- a/src/main/java/com/factotum/rin/model/BudgetCategory.java
+++ b/src/main/java/com/factotum/rin/model/BudgetCategory.java
@@ -1,5 +1,6 @@
 package com.factotum.rin.model;
 
+import com.factotum.rin.enumeration.BudgetType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +11,8 @@ import lombok.ToString;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -34,6 +37,10 @@ public class BudgetCategory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "budget_category_id")
     private Integer id;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "budget_type")
+    private BudgetType budgetType;
 
     @EqualsAndHashCode.Exclude
     @OneToOne

--- a/src/main/java/com/factotum/rin/repository/BudgetRepository.java
+++ b/src/main/java/com/factotum/rin/repository/BudgetRepository.java
@@ -2,6 +2,7 @@ package com.factotum.rin.repository;
 
 import com.factotum.rin.dto.BudgetCategoryInUse;
 import com.factotum.rin.dto.BudgetSummary;
+import com.factotum.rin.enumeration.BudgetType;
 import com.factotum.rin.model.Budget;
 import com.factotum.rin.model.BudgetCategoryType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -41,7 +42,7 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
             "new com.factotum.rin.dto.BudgetSummary(" +
             "   bct.name, " +
             "   bct.id, " +
-            "   b.transactionTypeId, " +
+            "   bc.budgetType, " +
             "   SUM(b.amount * f.monthFactor) " +
             ") " +
             "FROM Budget b " +
@@ -50,7 +51,7 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
             "INNER JOIN b.frequencyType f " +
             "WHERE b.startDate <= :startDate AND (b.endDate IS NULL OR b.endDate >= :endDate) " +
             "AND b.tenantId = :tenantId " +
-            "GROUP BY bct.name, b.transactionTypeId " +
+            "GROUP BY bct.name, bc.budgetType " +
             "ORDER BY bct.name ")
     List<BudgetSummary> getBudgetSummaries(
             @Param("startDate") ZonedDateTime startDate,
@@ -64,9 +65,9 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
                     "WHERE b.startDate <= :startDate " +
                     "AND (b.endDate IS NULL OR b.endDate >= :endDate) " +
                     "AND t.id = :budgetCategoryTypeId " +
-                    "AND b.transactionTypeId = :transactionTypeId " +
+                    "AND bc.budgetType = :budgetType " +
                     "AND b.tenantId = :tenantId")
     Set<Long> queryAllBudgetIdsForSummary(
-            int transactionTypeId, int budgetCategoryTypeId, ZonedDateTime startDate, ZonedDateTime endDate, String tenantId);
+            BudgetType budgetType, int budgetCategoryTypeId, ZonedDateTime startDate, ZonedDateTime endDate, String tenantId);
 
 }

--- a/src/main/resources/db/migration/V4_0__convert_to_budget_type.sql
+++ b/src/main/resources/db/migration/V4_0__convert_to_budget_type.sql
@@ -1,0 +1,9 @@
+ALTER TABLE budget_category ADD COLUMN budget_type VARCHAR(9);
+
+UPDATE budget_category bc
+SET bc.budget_type = 'INCOME'
+WHERE bc.budget_category_name_id IN (Select budget_category_name_id FROM budget_category_name WHERE category_name = 'income');
+
+UPDATE budget_category bc
+SET bc.budget_type = 'EXPENSE'
+WHERE bc.budget_category_name_id IN (Select budget_category_name_id FROM budget_category_name WHERE category_name <> 'income');

--- a/src/test/java/com/factotum/rin/controller/BudgetControllerIT.java
+++ b/src/test/java/com/factotum/rin/controller/BudgetControllerIT.java
@@ -4,6 +4,7 @@ import com.factotum.rin.IntegrationTest;
 import com.factotum.rin.dto.BudgetCategoryDto;
 import com.factotum.rin.dto.BudgetDto;
 import com.factotum.rin.dto.TransactionTotal;
+import com.factotum.rin.enumeration.BudgetType;
 import com.factotum.rin.http.TransactionService;
 import com.factotum.rin.model.BudgetCategory;
 import com.factotum.rin.repository.BudgetCategoryRepository;
@@ -258,7 +259,7 @@ class BudgetControllerIT {
 
         int expectedSize = 5;
 
-        when(transactionService.getTransactionTotal(anyInt(), anyInt(), anyInt(), any())).thenAnswer(i -> new TransactionTotal("TransactionType", BigDecimal.ONE));
+        when(transactionService.getTransactionTotal(anyInt(), anyInt(), any(), any())).thenAnswer(i -> new TransactionTotal(BudgetType.EXPENSE, BigDecimal.ONE));
 
         mockMvc.perform(
                 get(URI + "/summary")

--- a/src/test/java/com/factotum/rin/repository/BudgetRepositoryIT.java
+++ b/src/test/java/com/factotum/rin/repository/BudgetRepositoryIT.java
@@ -2,6 +2,7 @@ package com.factotum.rin.repository;
 
 import com.factotum.rin.dto.BudgetCategoryInUse;
 import com.factotum.rin.dto.BudgetSummary;
+import com.factotum.rin.enumeration.BudgetType;
 import com.factotum.rin.model.BudgetCategoryType;
 import com.factotum.rin.util.SecurityTestUtil;
 import org.junit.jupiter.api.Test;
@@ -65,20 +66,20 @@ class BudgetRepositoryIT {
 
         for (BudgetSummary summary : summaries) {
             int categoryId = summary.getCategoryId();
-            int transactionTypeId = summary.getTransactionTypeId();
-            if (categoryId == 3 && transactionTypeId == 2) {
+            BudgetType budgetType = summary.getBudgetType();
+            if (categoryId == 3 && BudgetType.EXPENSE.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(1674.99999967))));
                 summariesChecked++;
-            } else if (categoryId == 1 && transactionTypeId == 1) {
+            } else if (categoryId == 1 && BudgetType.INCOME.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(3000.0))));
                 summariesChecked++;
-            } else if (categoryId == 1 && transactionTypeId == 2) {
+            } else if (categoryId == 1 && BudgetType.EXPENSE.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(2127.5699999999997))));
                 summariesChecked++;
-            } else if (categoryId == 2 && transactionTypeId == 1) {
+            } else if (categoryId == 2 && BudgetType.INCOME.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(0.0))));
                 summariesChecked++;
-            } else if (categoryId == 2 && transactionTypeId == 2) {
+            } else if (categoryId == 2 && BudgetType.EXPENSE.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(350.0))));
                 summariesChecked++;
             }

--- a/src/test/java/com/factotum/rin/service/BudgetServiceImplIT.java
+++ b/src/test/java/com/factotum/rin/service/BudgetServiceImplIT.java
@@ -3,6 +3,7 @@ package com.factotum.rin.service;
 import com.factotum.rin.dto.BudgetCategoryDto;
 import com.factotum.rin.dto.BudgetItemDto;
 import com.factotum.rin.dto.BudgetSummary;
+import com.factotum.rin.enumeration.BudgetType;
 import com.factotum.rin.model.Budget;
 import com.factotum.rin.model.BudgetCategory;
 import com.factotum.rin.model.BudgetItem;
@@ -66,20 +67,20 @@ class BudgetServiceImplIT {
         System.out.println(summaries);
         for (BudgetSummary summary : summaries) {
             int categoryId = summary.getCategoryId();
-            int transactionTypeId = summary.getTransactionTypeId();
-            if (categoryId == 3 && transactionTypeId == 2) {
+            BudgetType budgetType = summary.getBudgetType();
+            if (categoryId == 3 && BudgetType.EXPENSE.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(1674.99999967))));
                 summariesChecked++;
-            } else if (categoryId == 1 && transactionTypeId == 1) {
+            } else if (categoryId == 1 && BudgetType.INCOME.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(3000.0))));
                 summariesChecked++;
-            } else if (categoryId == 1 && transactionTypeId == 2) {
+            } else if (categoryId == 1 && BudgetType.EXPENSE.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(2127.5699999999997))));
                 summariesChecked++;
-            } else if (categoryId == 2 && transactionTypeId == 1) {
+            } else if (categoryId == 2 && BudgetType.INCOME.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(0.0))));
                 summariesChecked++;
-            } else if (categoryId == 2 && transactionTypeId == 2) {
+            } else if (categoryId == 2 && BudgetType.EXPENSE.equals(budgetType)) {
                 assertThat(summary.getPlanned(), is(equalTo(BigDecimal.valueOf(350.0))));
                 summariesChecked++;
             }

--- a/src/test/java/com/factotum/rin/service/BudgetServiceImplUT.java
+++ b/src/test/java/com/factotum/rin/service/BudgetServiceImplUT.java
@@ -7,6 +7,7 @@ import com.factotum.rin.dto.BudgetSummary;
 import com.factotum.rin.dto.BudgetTypeDto;
 import com.factotum.rin.dto.TransactionBudgetSummary;
 import com.factotum.rin.dto.TransactionTotal;
+import com.factotum.rin.enumeration.BudgetType;
 import com.factotum.rin.http.TransactionService;
 import com.factotum.rin.model.Budget;
 import com.factotum.rin.model.BudgetCategory;
@@ -58,10 +59,13 @@ class BudgetServiceImplUT {
 
     @Mock
     private BudgetCategoryRepository budgetCategoryRepository;
+
     @Mock
     private BudgetRepository budgetRepository;
+
     @Mock
     private FrequencyTypeRepository frequencyTypeRepository;
+
     @Mock
     private TransactionService transactionService;
 
@@ -337,7 +341,7 @@ class BudgetServiceImplUT {
 
         // Arrange
         TransactionBudgetSummary summary = new TransactionBudgetSummary(
-                "TestType", "TestCategory", 1, 2017, 50.02, BigDecimal.valueOf(40.30), true);
+                BudgetType.INCOME, "TestCategory", 1, 2017, 50.02, BigDecimal.valueOf(40.30), true);
 
         when(budgetRepository.getBudgetSummaries(any(), any(), anyString()))
                 .thenReturn(
@@ -345,14 +349,14 @@ class BudgetServiceImplUT {
                                 new BudgetSummary(
                                         "TestCategory",
                                         1,
-                                        1,
+                                        BudgetType.INCOME,
                                         50.02)));
 
-        when(budgetRepository.queryAllBudgetIdsForSummary(anyInt(), anyInt(), any(), any(), anyString()))
+        when(budgetRepository.queryAllBudgetIdsForSummary(any(), anyInt(), any(), any(), anyString()))
                 .thenReturn(new HashSet<>(Collections.singletonList(1L)));
 
         //noinspection unchecked
-        when(transactionService.getTransactionTotal(eq(2017), eq(1), eq(1), any(Set.class))).thenReturn(new TransactionTotal("TestType", BigDecimal.valueOf(40.30)));
+        when(transactionService.getTransactionTotal(eq(2017), eq(1), eq(BudgetType.INCOME), any(Set.class))).thenReturn(new TransactionTotal(BudgetType.INCOME, BigDecimal.valueOf(40.30)));
 
         // Act
         List<TransactionBudgetSummary> summaries = budgetService.getBudgetSummary(SecurityTestUtil.getTestJwt(), 2017, 1);

--- a/src/test/java/com/factotum/rin/util/BudgetUtilUT.java
+++ b/src/test/java/com/factotum/rin/util/BudgetUtilUT.java
@@ -3,6 +3,7 @@ package com.factotum.rin.util;
 import com.factotum.rin.dto.BudgetCategoryDto;
 import com.factotum.rin.dto.BudgetDto;
 import com.factotum.rin.dto.BudgetItemDto;
+import com.factotum.rin.enumeration.BudgetType;
 import com.factotum.rin.model.Budget;
 import com.factotum.rin.model.BudgetCategory;
 import com.factotum.rin.model.BudgetCategoryName;
@@ -214,7 +215,7 @@ class BudgetUtilUT {
         BudgetCategoryName budgetCategoryName = new BudgetCategoryName(2, "TestBudgetCategoryName");
 
 
-        BudgetCategory budgetCategory = new BudgetCategory(1, budgetCategoryType, budgetCategoryName, new HashSet<>());
+        BudgetCategory budgetCategory = new BudgetCategory(1, BudgetType.INCOME, budgetCategoryType, budgetCategoryName, new HashSet<>());
 
         BudgetItem itemOne = new BudgetItem(6L, budgetCategory, "Item Name");
 

--- a/src/test/resources/bootstrap.yml
+++ b/src/test/resources/bootstrap.yml
@@ -1,0 +1,4 @@
+spring:
+  cloud:
+    kubernetes:
+      enabled: false


### PR DESCRIPTION
Fixes the exception thrown when getting the budget summary.

Budgets were never saving the transaction type on creation or update. This caused the query to fail. To fix this, the transaction type table was fully removed and replaced with an enum that defined it on the budget category level rather than on the budget or transaction level. Transactions are now evaluated to be expense or income based on whether their value is negative or positive.

BREAKING CHANGE